### PR TITLE
Terraformとaws-providerのバージョンアップ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.11
 
-ARG TERRAFORM_VERSION=0.12.24
+ARG TERRAFORM_VERSION=0.12.25
 
-RUN set -x \
+RUN set -eux \
   && apk update\
   && apk add --no-cache curl bash\
   && curl -fSL -o terraform.zip  https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ tfenvとDockerの利用を紹介します。
 
 その後以下の手順で設定を行います。
 
-- `tfenv install 0.12.24`
-- `tfenv use 0.12.24`
-- `terraform --version` で Terraform v0.12.24 が表示されればOK
+- `tfenv install 0.12.25`
+- `tfenv use 0.12.25`
+- `terraform --version` で Terraform v0.12.25 が表示されればOK
 
 #### Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '3.7'
+version: '3.8'
 services:
   terraform:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        - TERRAFORM_VERSION=0.12.24
     tty: true
     volumes:
       - .:/data

--- a/providers/aws/environments/dev/10-network/versions.tf
+++ b/providers/aws/environments/dev/10-network/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = "0.12.25"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.62.0"
   }
 }

--- a/providers/aws/environments/prod/10-network/versions.tf
+++ b/providers/aws/environments/prod/10-network/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "0.12.24"
+  required_version = "0.12.25"
 
   required_providers {
-    aws = "2.57.0"
+    aws = "2.62.0"
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/terraform-boilerplate/issues/9

# Doneの定義
- https://github.com/nekochans/terraform-boilerplate/issues/9 の完了の定義を満たしている事

# 変更点概要

## 技術的変更点概要
- terraformのバージョンを `0.12.25` に変更
- terraform-aws-providerのバージョンを `2.62.0` に変更

上記に加えて軽微なリファクタリングを実施。詳しくはインラインコメントに記載してある。